### PR TITLE
Liaoz

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -50,6 +50,7 @@ android {
         abortOnError false
     }
 
+    buildToolsVersion '25.0.0'
 }
 
 task makeApk {

--- a/app/src/main/java/com/lzy/demo/GApp.java
+++ b/app/src/main/java/com/lzy/demo/GApp.java
@@ -55,9 +55,9 @@ public class GApp extends Application {
                     .debug("OkGo", Level.INFO, true)
 
                     //如果使用默认的 60秒,以下三行也不需要传
-                    .setConnectTimeout(OkGo.DEFAULT_MILLISECONDS)  //全局的连接超时时间
-                    .setReadTimeOut(OkGo.DEFAULT_MILLISECONDS)     //全局的读取超时时间
-                    .setWriteTimeOut(OkGo.DEFAULT_MILLISECONDS)    //全局的写入超时时间
+                    .setConnectTimeout(OkGo.DEFAULT_CONNECT_TIMEOUT)  //全局的连接超时时间
+                    .setReadTimeOut(OkGo.DEFAULT_READ_TIMEOUT)     //全局的读取超时时间
+                    .setWriteTimeOut(OkGo.DEFAULT_WRITE_TIMEOUT)    //全局的写入超时时间
 
                     //可以全局统一设置缓存模式,默认是不使用缓存,可以不传,具体其他模式看 github 介绍 https://github.com/jeasonlzy/
                     .setCacheMode(CacheMode.NO_CACHE)

--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:2.2.2'
+        classpath 'com.android.tools.build:gradle:2.3.2'
 
         classpath 'com.jfrog.bintray.gradle:gradle-bintray-plugin:1.7'
         classpath 'com.github.dcendents:android-maven-gradle-plugin:1.5'

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
-#Mon Oct 31 13:50:05 CST 2016
+#Thu May 25 08:35:35 CST 2017
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.14.1-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-3.3-all.zip

--- a/okgo/build.gradle
+++ b/okgo/build.gradle
@@ -2,7 +2,7 @@ apply plugin: 'com.android.library'
 
 android {
     compileSdkVersion 24
-    buildToolsVersion "24.0.3"
+    buildToolsVersion '25.0.0'
 
     defaultConfig {
         minSdkVersion 9
@@ -14,7 +14,7 @@ android {
 
 dependencies {
     compile fileTree(dir: 'libs', include: ['*.jar'])
-    compile 'com.squareup.okhttp3:okhttp:3.4.1'
+    compile 'com.squareup.okhttp3:okhttp:3.8.0'
 }
 
 //apply from: 'bintray.gradle'、

--- a/okgo/src/main/java/com/lzy/okgo/OkGo.java
+++ b/okgo/src/main/java/com/lzy/okgo/OkGo.java
@@ -42,7 +42,9 @@ import okhttp3.OkHttpClient;
  * ================================================
  */
 public class OkGo {
-    public static final int DEFAULT_MILLISECONDS = 60000;       //默认的超时时间
+    public static final int DEFAULT_CONNECT_TIMEOUT = 60_000;   //默认的超时时间
+    public static final int DEFAULT_READ_TIMEOUT = 60_000;      //默认的超时时间
+    public static final int DEFAULT_WRITE_TIMEOUT = 60_000;     //默认的超时时间
     public static int REFRESH_TIME = 100;                       //回调刷新时间（单位ms）
 
     private Handler mDelivery;                                  //用于在主线程执行的调度器
@@ -59,9 +61,9 @@ public class OkGo {
     private OkGo() {
         okHttpClientBuilder = new OkHttpClient.Builder();
         okHttpClientBuilder.hostnameVerifier(HttpsUtils.UnSafeHostnameVerifier);
-        okHttpClientBuilder.connectTimeout(DEFAULT_MILLISECONDS, TimeUnit.MILLISECONDS);
-        okHttpClientBuilder.readTimeout(DEFAULT_MILLISECONDS, TimeUnit.MILLISECONDS);
-        okHttpClientBuilder.writeTimeout(DEFAULT_MILLISECONDS, TimeUnit.MILLISECONDS);
+        okHttpClientBuilder.connectTimeout(DEFAULT_CONNECT_TIMEOUT, TimeUnit.MILLISECONDS);
+        okHttpClientBuilder.readTimeout(DEFAULT_READ_TIMEOUT, TimeUnit.MILLISECONDS);
+        okHttpClientBuilder.writeTimeout(DEFAULT_WRITE_TIMEOUT, TimeUnit.MILLISECONDS);
         mDelivery = new Handler(Looper.getMainLooper());
     }
 

--- a/okgo/src/main/java/com/lzy/okgo/OkGo.java
+++ b/okgo/src/main/java/com/lzy/okgo/OkGo.java
@@ -42,9 +42,9 @@ import okhttp3.OkHttpClient;
  * ================================================
  */
 public class OkGo {
-    public static final int DEFAULT_CONNECT_TIMEOUT = 60_000;   //默认的超时时间
-    public static final int DEFAULT_READ_TIMEOUT = 60_000;      //默认的超时时间
-    public static final int DEFAULT_WRITE_TIMEOUT = 60_000;     //默认的超时时间
+    public static final int DEFAULT_CONNECT_TIMEOUT = 60_000;   //默认连接超时时间
+    public static final int DEFAULT_READ_TIMEOUT = 60_000;      //默认读取超时时间
+    public static final int DEFAULT_WRITE_TIMEOUT = 60_000;     //默认写入超时时间
     public static int REFRESH_TIME = 100;                       //回调刷新时间（单位ms）
 
     private Handler mDelivery;                                  //用于在主线程执行的调度器

--- a/okrx/build.gradle
+++ b/okrx/build.gradle
@@ -2,7 +2,7 @@ apply plugin: 'com.android.library'
 
 android {
     compileSdkVersion 24
-    buildToolsVersion "24.0.3"
+    buildToolsVersion '25.0.0'
 
     defaultConfig {
         minSdkVersion 9

--- a/okserver/build.gradle
+++ b/okserver/build.gradle
@@ -2,7 +2,7 @@ apply plugin: 'com.android.library'
 
 android {
     compileSdkVersion 24
-    buildToolsVersion "24.0.3"
+    buildToolsVersion '25.0.0'
 
     defaultConfig {
         minSdkVersion 9


### PR DESCRIPTION
（1）将原来的默认时间，拆分为连接，读取，写入三个常量，常量的值没有改变，保持60s
（2）升级构建和编译工具版本
（3）升级依赖库okhttp版本到3.8.0
第一次推送请求，有什么不对的地方请指正。