### PR TITLE
添加是否使用ProgressRequestBody的开关

### DIFF
--- a/okgo/src/main/java/com/lzy/okgo/request/base/BodyRequest.java
+++ b/okgo/src/main/java/com/lzy/okgo/request/base/BodyRequest.java
@@ -53,6 +53,8 @@ public abstract class BodyRequest<T, R extends BodyRequest> extends Request<T, R
 
     protected boolean isMultipart = false;  //是否强制使用 multipart/form-data 表单上传
     protected boolean isSpliceUrl = false;  //是否拼接url参数
+    protected boolean isNeedProgress = false;  //是否监察进度
+
     protected RequestBody requestBody;
 
     public BodyRequest(String url) {
@@ -72,6 +74,14 @@ public abstract class BodyRequest<T, R extends BodyRequest> extends Request<T, R
         this.isSpliceUrl = isSpliceUrl;
         return (R) this;
     }
+
+    @SuppressWarnings("unchecked")
+    @Override
+    public R isNeedProgress(boolean isNeedProgress) {
+        this.isNeedProgress = isNeedProgress;
+        return (R) this;
+    }
+
 
     @SuppressWarnings("unchecked")
     @Override
@@ -208,6 +218,12 @@ public abstract class BodyRequest<T, R extends BodyRequest> extends Request<T, R
         if (bs != null && mediaType != null) return RequestBody.create(mediaType, bs);              //上传字节数组
         if (file != null && mediaType != null) return RequestBody.create(mediaType, file);          //上传一个文件
         return HttpUtils.generateMultipartRequestBody(params, isMultipart);
+    }
+
+
+    @Override
+    public boolean getNeedProgress() {
+        return isNeedProgress;
     }
 
     protected okhttp3.Request.Builder generateRequestBuilder(RequestBody requestBody) {

--- a/okgo/src/main/java/com/lzy/okgo/request/base/HasBody.java
+++ b/okgo/src/main/java/com/lzy/okgo/request/base/HasBody.java
@@ -41,6 +41,8 @@ public interface HasBody<R> {
 
     R isSpliceUrl(boolean isSpliceUrl);
 
+    R isNeedProgress(boolean isNeedProgress);
+
     R upRequestBody(RequestBody requestBody);
 
     R params(String key, File file);

--- a/okgo/src/main/java/com/lzy/okgo/request/base/Request.java
+++ b/okgo/src/main/java/com/lzy/okgo/request/base/Request.java
@@ -336,21 +336,27 @@ public abstract class Request<T, R extends Request> implements Serializable {
     /** 根据不同的请求方式，将RequestBody转换成Request对象 */
     public abstract okhttp3.Request generateRequest(RequestBody requestBody);
 
-    /** 获取okhttp的同步call对象 */
+    public boolean getNeedProgress() {
+        return false;
+    }
+
+    /**
+     * 获取okhttp的同步call对象
+     */
     public okhttp3.Call getRawCall() {
         //构建请求体，返回call对象
         RequestBody requestBody = generateRequestBody();
-        if (requestBody != null) {
+
+        if (requestBody != null && getNeedProgress()) {
             ProgressRequestBody<T> progressRequestBody = new ProgressRequestBody<>(requestBody, callback);
             progressRequestBody.setInterceptor(uploadInterceptor);
             mRequest = generateRequest(progressRequestBody);
         } else {
-            mRequest = generateRequest(null);
+            mRequest = generateRequest(requestBody);
         }
         if (client == null) client = OkGo.getInstance().getOkHttpClient();
         return client.newCall(mRequest);
     }
-
     /** Rx支持，获取同步call对象 */
     public Call<T> adapt() {
         if (call == null) {


### PR DESCRIPTION
默认不使用ProgressRequestBody封装RequestBody，因为通常情况下是不需要监听进度的，大多时候只会对okhttp的FormBody做处理，我在拦截器里找为什么RequestBody不是instanceof FormBody找了半天