### PR TITLE
解决 onError中 异常类 拿不到 404 5xx的情况

### DIFF
--- a/okgo/src/main/java/com/lzy/okgo/cache/policy/BaseCachePolicy.java
+++ b/okgo/src/main/java/com/lzy/okgo/cache/policy/BaseCachePolicy.java
@@ -23,7 +23,7 @@ import com.lzy.okgo.cache.CacheMode;
 import com.lzy.okgo.callback.Callback;
 import com.lzy.okgo.db.CacheManager;
 import com.lzy.okgo.exception.HttpException;
-import com.lzy.okgo.exception.MyHttpException;
+import com.lzy.okgo.exception.HttpException1;
 import com.lzy.okgo.model.Response;
 import com.lzy.okgo.request.base.Request;
 import com.lzy.okgo.utils.HeaderParser;
@@ -106,7 +106,7 @@ public abstract class BaseCachePolicy<T> implements CachePolicy<T> {
             if (responseCode == 404 || responseCode >= 500) {
                 String message = response.message();
                 String string = response.body().string();
-                return Response.error(false, rawCall, response, new MyHttpException(responseCode, message, string));
+                return Response.error(false, rawCall, response, new HttpException1(responseCode, message, string));
             }
 
             T body = request.getConverter().convertResponse(response);
@@ -154,7 +154,9 @@ public abstract class BaseCachePolicy<T> implements CachePolicy<T> {
 
                 //network error
                 if (responseCode == 404 || responseCode >= 500) {
-                    Response<T> error = Response.error(false, call, response, HttpException.NET_ERROR());
+                    String message = response.message();
+                    String string = response.body().string();
+                    Response<T> error = Response.error(false, call, response, new HttpException1(responseCode,message,string));
                     onError(error);
                     return;
                 }

--- a/okgo/src/main/java/com/lzy/okgo/cache/policy/BaseCachePolicy.java
+++ b/okgo/src/main/java/com/lzy/okgo/cache/policy/BaseCachePolicy.java
@@ -23,6 +23,7 @@ import com.lzy.okgo.cache.CacheMode;
 import com.lzy.okgo.callback.Callback;
 import com.lzy.okgo.db.CacheManager;
 import com.lzy.okgo.exception.HttpException;
+import com.lzy.okgo.exception.MyHttpException;
 import com.lzy.okgo.model.Response;
 import com.lzy.okgo.request.base.Request;
 import com.lzy.okgo.utils.HeaderParser;
@@ -101,10 +102,11 @@ public abstract class BaseCachePolicy<T> implements CachePolicy<T> {
         try {
             okhttp3.Response response = rawCall.execute();
             int responseCode = response.code();
-
             //network error
             if (responseCode == 404 || responseCode >= 500) {
-                return Response.error(false, rawCall, response, HttpException.NET_ERROR());
+                String message = response.message();
+                String string = response.body().string();
+                return Response.error(false, rawCall, response, new MyHttpException(responseCode, message, string));
             }
 
             T body = request.getConverter().convertResponse(response);

--- a/okgo/src/main/java/com/lzy/okgo/exception/HttpException1.java
+++ b/okgo/src/main/java/com/lzy/okgo/exception/HttpException1.java
@@ -1,11 +1,11 @@
 package com.lzy.okgo.exception;
 
-public class MyHttpException extends RuntimeException {
+public class HttpException1 extends RuntimeException {
     private int code;
     private String message;
     private String body;
 
-    public MyHttpException(int code, String message, String body) {
+    public HttpException1(int code, String message, String body) {
         this.code = code;
         this.message = message;
         this.body = body;

--- a/okgo/src/main/java/com/lzy/okgo/exception/MyHttpException.java
+++ b/okgo/src/main/java/com/lzy/okgo/exception/MyHttpException.java
@@ -1,0 +1,39 @@
+package com.lzy.okgo.exception;
+
+public class MyHttpException extends RuntimeException {
+    private int code;
+    private String message;
+    private String body;
+
+    public MyHttpException(int code, String message, String body) {
+        this.code = code;
+        this.message = message;
+        this.body = body;
+    }
+
+
+    public int getCode() {
+        return code;
+    }
+
+    public void setCode(int code) {
+        this.code = code;
+    }
+
+    @Override
+    public String getMessage() {
+        return message;
+    }
+
+    public void setMessage(String message) {
+        this.message = message;
+    }
+
+    public String getBody() {
+        return body;
+    }
+
+    public void setBody(String body) {
+        this.body = body;
+    }
+}


### PR DESCRIPTION
自定义了一个异常类 HttpException1
在 BaseCachePolicy中 对于404 5xx请求 的抛出的异常类进行封装，存入code message body等信息
方便 在 onError中进行获取 做适应性 提示或者操作
