### PR TITLE
添加对 okHttpClient callTimeout 的支持

### DIFF
--- a/okgo/src/main/java/com/lzy/okgo/OkGo.java
+++ b/okgo/src/main/java/com/lzy/okgo/OkGo.java
@@ -80,6 +80,7 @@ public class OkGo {
         builder.readTimeout(OkGo.DEFAULT_MILLISECONDS, TimeUnit.MILLISECONDS);
         builder.writeTimeout(OkGo.DEFAULT_MILLISECONDS, TimeUnit.MILLISECONDS);
         builder.connectTimeout(OkGo.DEFAULT_MILLISECONDS, TimeUnit.MILLISECONDS);
+        builder.callTimeout(OkGo.DEFAULT_MILLISECONDS, TimeUnit.MILLISECONDS);
 
         HttpsUtils.SSLParams sslParams = HttpsUtils.getSslSocketFactory();
         builder.sslSocketFactory(sslParams.sSLSocketFactory, sslParams.trustManager);

--- a/okgo/src/main/java/com/lzy/okgo/cache/policy/BaseCachePolicy.java
+++ b/okgo/src/main/java/com/lzy/okgo/cache/policy/BaseCachePolicy.java
@@ -142,6 +142,12 @@ public abstract class BaseCachePolicy<T> implements CachePolicy<T> {
                     if (!call.isCanceled()) {
                         Response<T> error = Response.error(false, call, null, e);
                         onError(error);
+                    } else {
+                        // 这个 `else` 是为了解决 callTimeout 无法触发 onError 回调
+                        if (e instanceof InterruptedIOException) {
+                            Response<T> error = Response.error(false, call, null, e);
+                            onError(error);
+                        }
                     }
                 }
             }


### PR DESCRIPTION
添加对 okHttpClient callTimeout 的支持.

解决了这个 issue: #937 callTimeout 不会回调到 onError.